### PR TITLE
fix json syntax

### DIFF
--- a/pleroma-manifest/manifest.json
+++ b/pleroma-manifest/manifest.json
@@ -138,7 +138,7 @@
 	"rain_hugs": {
 		"description": "Neocritters hugging Rain!",
 		"files": "rain_hugs_files.json",
-		"homepage": "https://github.com/SymTrkl/emoji/releases/tag/rain_hugs"
+		"homepage": "https://github.com/SymTrkl/emoji/releases/tag/rain_hugs",
 		"license": "CC-BY-NC-SA-4.0",
 		"src": "https://github.com/SymTrkl/emoji/releases/download/rain_hugs/rain_hugs.zip",
 		"src_sha256": "666f9d057c05e7620a850ec5ea01b01db9f79a838506fcf5fc8d5dbc74800e7b"


### PR DESCRIPTION
This fixes a JSON syntax error in the Pleroma Emoji pack manifest that prevents imports via pleroma_ctl.

With the error present, this happens:

```
$ pleroma_ctl emoji get-packs -m https://raw.githubusercontent.com/SymTrkl/emoji/refs/heads/main/pleroma-manifest/manifest.json neobot

12:44:21.531 [debug] Outbound: get https://raw.githubusercontent.com/SymTrkl/emoji/refs/heads/main/pleroma-manifest/manifest.json
** (Jason.DecodeError) unexpected byte at position 7904: 0x22 ("\"")
    lib/jason.ex:92: Jason.decode!/2
    lib/mix/tasks/pleroma/emoji.ex:45: Mix.Tasks.Pleroma.Emoji.run/1
    nofile:1: (file)
    (stdlib 5.0.2) erl_eval.erl:750: :erl_eval.do_apply/7
    (elixir 1.15.4) lib/code.ex:543: Code.validated_eval_string/3
```